### PR TITLE
Schemafy 커스텀

### DIFF
--- a/schemafy_lib/src/generator.rs
+++ b/schemafy_lib/src/generator.rs
@@ -53,13 +53,6 @@ impl<'a, 'b> Generator<'a, 'b> {
             )
         });
 
-        schema.items.get_mut(0)
-            .map(|e| e.properties.get_mut("property")
-                .map(|e| {
-                    e.additional_properties = None;
-                    e.properties.clear();
-                }));
-
         let mut expander = Expander::new(self.root_name.as_deref(), self.schemafy_path, &schema);
         expander.expand(&schema)
     }


### PR DESCRIPTION
- required 표시된 필드만 코드로 전환
- optional 필드도 적용 가능하도록 flatten 기능 추가
- optional 필드라도 Object 정의가 포함된 필드이면 코드에 추가
- inner type 네이밍 규칙 변경
- default 값 설정 기능 추가